### PR TITLE
Update package exports for legacy build system compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavecx/wavecx-react",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "WaveCX React library",
   "homepage": "https://github.com/WaveCX/wavecx-react#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "type": "module",
   "source": "src/index",
   "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
   "style": "dist/styles.css",
   "types": "dist/index.d.ts",
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ export default [
         sourcemap: true,
       },
       {
-        file: packageInfo.module,
+        file: packageInfo.exports['.'].import,
         format: 'esm',
         sourcemap: true,
       },


### PR DESCRIPTION
Old build systems like Webpack 4 incorrectly prioritize the `module` field in package.json, and will import ESM based on it despite not actually supporting ESM.

This change removes the `module` field to allow compatibility with build systems like this. Modern build systems will still receive correct ESM imports via the `exports` field.